### PR TITLE
Release `1.25.13`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ CHANGELOG
 
 **Übersetzungen für Erweiterungen aktualisiert**:
 
+* [`clarkwinkelmann/flarum-ext-carving-contest`](https://github.com/clarkwinkelmann/flarum-ext-carving-contest)
 * [`clarkwinkelmann/flarum-ext-emojionearea`](https://github.com/clarkwinkelmann/flarum-ext-emojionearea)
+* [`justoverclock/flarum-ext-feedback`](https://github.com/justoverclockl/flarum-ext-feedback)
+* [`kilowhat/flarum-ext-audit-free`](https://github.com/kilowhat/flarum-ext-audit-free)
 * [`ralkage/flarum-ext-ad-management`](https://github.com/Ralkage/flarum-ext-ad-management)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@ CHANGELOG
 1.25.13 (XXXX-XX-XX)
 --------------------
 
+**Unterstützung für neue Erweiterungen hinzugefügt**:
+
+* [`justoverclock/auto-post-count-badge`](https://github.com/justoverclockl/auto-post-count-badge)
+* [`resofire/digest-mail`](https://github.com/ResofireV2/digest-mail)
+
+
 **Übersetzungen für Erweiterungen aktualisiert**:
 
-* [`ralkage/flarum-ext-ad-management`](https://github.com/Ralkage/flarum-ext-ad-management)
 * [`clarkwinkelmann/flarum-ext-emojionearea`](https://github.com/clarkwinkelmann/flarum-ext-emojionearea)
+* [`ralkage/flarum-ext-ad-management`](https://github.com/Ralkage/flarum-ext-ad-management)
 
 
 Alle Änderungen: [1.25.12...1.25.13](https://github.com/flarum-lang/german/compare/1.25.12...1.25.13).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@ CHANGELOG
 =========
 
 
+1.25.13 (XXXX-XX-XX)
+--------------------
+
+**Übersetzungen für Erweiterungen aktualisiert**:
+
+* [`ralkage/flarum-ext-ad-management`](https://github.com/Ralkage/flarum-ext-ad-management)
+
+
+Alle Änderungen: [1.25.12...1.25.13](https://github.com/flarum-lang/german/compare/1.25.12...1.25.13).
+
+
 1.25.12 (2026-04-14)
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 
-1.25.13 (XXXX-XX-XX)
+1.25.13 (2026-04-18)
 --------------------
 
 **Unterstützung für neue Erweiterungen hinzugefügt**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 
 * [`clarkwinkelmann/flarum-ext-carving-contest`](https://github.com/clarkwinkelmann/flarum-ext-carving-contest)
 * [`clarkwinkelmann/flarum-ext-emojionearea`](https://github.com/clarkwinkelmann/flarum-ext-emojionearea)
+* [`fof/byobu`](https://github.com/FriendsOfFlarum/byobu)
 * [`fof/username-request`](https://github.com/FriendsOfFlarum/username-request)
 * [`justoverclock/flarum-ext-feedback`](https://github.com/justoverclockl/flarum-ext-feedback)
 * [`kilowhat/flarum-ext-audit-free`](https://github.com/kilowhat/flarum-ext-audit-free)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 
 * [`clarkwinkelmann/flarum-ext-carving-contest`](https://github.com/clarkwinkelmann/flarum-ext-carving-contest)
 * [`clarkwinkelmann/flarum-ext-emojionearea`](https://github.com/clarkwinkelmann/flarum-ext-emojionearea)
+* [`fof/username-request`](https://github.com/FriendsOfFlarum/username-request)
 * [`justoverclock/flarum-ext-feedback`](https://github.com/justoverclockl/flarum-ext-feedback)
 * [`kilowhat/flarum-ext-audit-free`](https://github.com/kilowhat/flarum-ext-audit-free)
 * [`ralkage/flarum-ext-ad-management`](https://github.com/Ralkage/flarum-ext-ad-management)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 **Übersetzungen für Erweiterungen aktualisiert**:
 
 * [`ralkage/flarum-ext-ad-management`](https://github.com/Ralkage/flarum-ext-ad-management)
+* [`clarkwinkelmann/flarum-ext-emojionearea`](https://github.com/clarkwinkelmann/flarum-ext-emojionearea)
 
 
 Alle Änderungen: [1.25.12...1.25.13](https://github.com/flarum-lang/german/compare/1.25.12...1.25.13).


### PR DESCRIPTION
This is a draft of changelog for the `1.25.13` release.
Here you can find all related translations changes: [1.25.12...master](https://github.com/flarum-lang/german/compare/1.25.12...master).

> ### ⚠️ Do not merge this pull request manually ⚠️
> 
> You should **[approve](https://github.com/rob006-software/flarum-translations/wiki/How-to-approve-release-pull-request)** this pull request instead. After approving, I will automatically update it (release date needs to be adjusted), merge, and tag a new release. You can read more about the process on [forum](https://discuss.flarum.org/d/20807-simplify-translation-process-with-weblate/76).

<details>
<summary>Show release notes preview</summary>

## 1.25.13

<!-- release-notes-begin -->
**Unterstützung für neue Erweiterungen hinzugefügt**:

* [`justoverclock/auto-post-count-badge`](https://github.com/justoverclockl/auto-post-count-badge)
* [`resofire/digest-mail`](https://github.com/ResofireV2/digest-mail)


**Übersetzungen für Erweiterungen aktualisiert**:

* [`clarkwinkelmann/flarum-ext-carving-contest`](https://github.com/clarkwinkelmann/flarum-ext-carving-contest)
* [`clarkwinkelmann/flarum-ext-emojionearea`](https://github.com/clarkwinkelmann/flarum-ext-emojionearea)
* [`fof/byobu`](https://github.com/FriendsOfFlarum/byobu)
* [`fof/username-request`](https://github.com/FriendsOfFlarum/username-request)
* [`justoverclock/flarum-ext-feedback`](https://github.com/justoverclockl/flarum-ext-feedback)
* [`kilowhat/flarum-ext-audit-free`](https://github.com/kilowhat/flarum-ext-audit-free)
* [`ralkage/flarum-ext-ad-management`](https://github.com/Ralkage/flarum-ext-ad-management)


Alle Änderungen: [1.25.12...1.25.13](https://github.com/flarum-lang/german/compare/1.25.12...1.25.13).



<!-- release-notes-end -->

</details>